### PR TITLE
Drive command

### DIFF
--- a/src/main/java/frc/robot/commands/DriveCommand.java
+++ b/src/main/java/frc/robot/commands/DriveCommand.java
@@ -1,0 +1,46 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import java.util.function.BooleanSupplier;
+import java.util.function.DoubleSupplier;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+
+public class DriveCommand extends CommandBase {
+  /** Creates a new DriveCommand. */
+
+  DriveTrain driveTrain;
+  DoubleSupplier throttle;
+  DoubleSupplier turn;
+  BooleanSupplier driveSwitch;
+  public DriveCommand(DriveTrain driveTrain, DoubleSupplier throttle, DoubleSupplier turn, BooleanSupplier driveSwitch) {
+    this.driveTrain = driveTrain;
+    this.throttle = throttle;
+    this.turn = turn;
+    this.driveSwitch = driveSwitch;
+    addRequirements(driveTrain);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {}
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    driveTrain.allDrive(throttle.getAsDouble(), turn.getAsDouble(), true, driveSwitch.getAsBoolean());
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {}
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/DriveCommand.java
+++ b/src/main/java/frc/robot/commands/DriveCommand.java
@@ -13,15 +13,15 @@ import frc.robot.subsystems.DriveTrain;
 public class DriveCommand extends CommandBase {
   /** Creates a new DriveCommand. */
 
-  DriveTrain driveTrain;
-  DoubleSupplier throttle;
-  DoubleSupplier turn;
-  BooleanSupplier driveSwitch;
+  DriveTrain m_driveTrain;
+  DoubleSupplier m_throttle;
+  DoubleSupplier m_turn;
+  BooleanSupplier m_driveSwitch;
   public DriveCommand(DriveTrain driveTrain, DoubleSupplier throttle, DoubleSupplier turn, BooleanSupplier driveSwitch) {
-    this.driveTrain = driveTrain;
-    this.throttle = throttle;
-    this.turn = turn;
-    this.driveSwitch = driveSwitch;
+    this.m_driveTrain = driveTrain;
+    this.m_throttle = throttle;
+    this.m_turn = turn;
+    this.m_driveSwitch = driveSwitch;
     addRequirements(driveTrain);
   }
 
@@ -32,7 +32,7 @@ public class DriveCommand extends CommandBase {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    driveTrain.allDrive(throttle.getAsDouble(), turn.getAsDouble(), true, driveSwitch.getAsBoolean());
+    m_driveTrain.allDrive(m_throttle.getAsDouble(), m_turn.getAsDouble(), true, m_driveSwitch.getAsBoolean());
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/DriveCommand.java
+++ b/src/main/java/frc/robot/commands/DriveCommand.java
@@ -8,6 +8,7 @@ import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.DriveTrain;
 
 public class DriveCommand extends CommandBase {
   /** Creates a new DriveCommand. */

--- a/src/main/java/frc/robot/commands/DriveCommand.java
+++ b/src/main/java/frc/robot/commands/DriveCommand.java
@@ -18,10 +18,10 @@ public class DriveCommand extends CommandBase {
   DoubleSupplier m_turn;
   BooleanSupplier m_driveSwitch;
   public DriveCommand(DriveTrain driveTrain, DoubleSupplier throttle, DoubleSupplier turn, BooleanSupplier driveSwitch) {
-    this.m_driveTrain = driveTrain;
-    this.m_throttle = throttle;
-    this.m_turn = turn;
-    this.m_driveSwitch = driveSwitch;
+    m_driveTrain = driveTrain;
+    m_throttle = throttle;
+    m_turn = turn;
+    m_driveSwitch = driveSwitch;
     addRequirements(driveTrain);
   }
 


### PR DESCRIPTION
In the 2020 robot, there wasn't a subsystem requirement for the drivetrain on this command. I added one here, was this correct?