### PR TITLE
Additional shoot buttons

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -96,8 +96,8 @@ public final class Constants {
     // We therefore subtract SHOOTER_POS from all shooting distance constants
     public static final double SHOOTER_POS = 24;
     
-    // Our usual "Tarmac" shot is 9ft
-    public static final double TARMAC_DEFAULT_DISTANCE = (12.0 * 9.0) - SHOOTER_POS;
+    // Our usual "Tarmac" shot 
+    public static final double TARMAC_DEFAULT_DISTANCE = 94.0;
     
     // distance from the edge of the field by the human shooting position
     public static final double JUST_OUTSIDE_TARMAC = (12.0 * 11.5) - SHOOTER_POS;
@@ -206,7 +206,8 @@ public final class Constants {
     public static final double CLIMB_TO_NEXT_BAR_TIMEOUT = 12.0;
 
     // robot starting distance
-    public static final double STARTING_DISTANCE = TARMAC_DEFAULT_DISTANCE - 10.0;
+    // this used to be TARMAC_DEFAULT_DISTANCE - 10.0, but adjusted to be closer at Revere
+    public static final double STARTING_DISTANCE = 74.0;
    
     // Xbox button mapping
     public static final int XBOX_A = 1;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -88,11 +88,12 @@ public final class Constants {
     // amount of time to shoot the second ball
     public static final double SHOOT_BALL2_WAIT_TIME = 0.75;
     
+    public static final double SHOOTER_POS = 24;//shooter position on the robot from the bumper
     public static final double TARMAC_DEFAULT_DISTANCE = 12.0 * 7.0;  // 9ft minus hub radius
-    public static final double FAR_LAUNCHPAD_SHOOTER_DISTANCE = 220.77;//distance from the far side of the launchpad to the center hub
-    public static final double CLOSE_LAUNCHPAD_SHOOTER_DISTANCE = 178.95;//distance from the close side of the launchpad to the center hub
-    public static final double HUMAN_PLAYER_SHOOTER_DISTANCE = 281.66;//distance from human shooter to center hub
-    public static final double FAR_SIDE_SHOOTER_DISTANCE = 300.0;//the side between launch pad and human shooter to center hub (least precise location)
+    public static final double FAR_LAUNCHPAD_SHOOTER_DISTANCE = 244.77 - SHOOTER_POS;//distance from the far side of the launchpad to the center hub
+    public static final double CLOSE_LAUNCHPAD_SHOOTER_DISTANCE = 202.95 - SHOOTER_POS;//distance from the close side of the launchpad to the center hub
+    public static final double HUMAN_PLAYER_SHOOTER_DISTANCE = 305.66 - SHOOTER_POS;//distance from human shooter to center hub
+    public static final double FAR_SIDE_SHOOTER_DISTANCE = 324.0 - SHOOTER_POS;//the side between launch pad and human shooter to center hub (least precise location)
 
     // chute subsystem
     public static final int CHUTE_CAN_ID = 6; 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -88,14 +88,31 @@ public final class Constants {
     // amount of time to shoot the second ball
     public static final double SHOOT_BALL2_WAIT_TIME = 0.75;
     
-    public static final double SHOOTER_POS = 24;//shooter position on the robot from the bumper
-    public static final double TARMAC_DEFAULT_DISTANCE = 12.0 * 7.0;  // 9ft minus hub radius
-    public static final double FAR_LAUNCHPAD_SHOOTER_DISTANCE = 244.77 - SHOOTER_POS;//distance from the far side of the launchpad to the center hub
-    public static final double CLOSE_LAUNCHPAD_SHOOTER_DISTANCE = 202.95 - SHOOTER_POS;//distance from the close side of the launchpad to the center hub
-    public static final double HUMAN_PLAYER_SHOOTER_DISTANCE = 305.66 - SHOOTER_POS;//distance from human shooter to center hub
-    public static final double FAR_SIDE_SHOOTER_DISTANCE = 324.0 - SHOOTER_POS;//the side between launch pad and human shooter to center hub (least precise location)
+    
+    //
+    // Various constants used for shooting
+    //
 
-    // chute subsystem
+    // The shooting mechanism is about 24" from the edge of the robot, including bumper
+    // We therefore subtract SHOOTER_POS from all shooting distance constants
+    public static final double SHOOTER_POS = 24;
+    
+    // Our usual "Tarmac" shot is 9ft
+    public static final double TARMAC_DEFAULT_DISTANCE = (12.0 * 9.0) - SHOOTER_POS;
+    
+    // distance from the edge of the field by the human shooting position
+    public static final double JUST_OUTSIDE_TARMAC = (12.0 * 11.5) - SHOOTER_POS;
+    
+    // distance from the near side launchpad to the center hub
+    public static final double CLOSE_LAUNCHPAD_SHOOTER_DISTANCE = 202.95 - SHOOTER_POS;
+    
+    // distance from the far side launchpad to the center hub
+    public static final double FAR_LAUNCHPAD_SHOOTER_DISTANCE = 244.77 - SHOOTER_POS;
+
+    //
+    //
+
+    // Chute subsystem
     public static final int CHUTE_CAN_ID = 6; 
 
     // define constants for high, low, and mid rung

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -89,6 +89,10 @@ public final class Constants {
     public static final double SHOOT_BALL2_WAIT_TIME = 0.75;
     
     public static final double TARMAC_DEFAULT_DISTANCE = 12.0 * 7.0;  // 9ft minus hub radius
+    public static final double FAR_LAUNCHPAD_SHOOTER_DISTANCE = 220.77;//distance from the far side of the launchpad to the center hub
+    public static final double CLOSE_LAUNCHPAD_SHOOTER_DISTANCE = 178.95;//distance from the close side of the launchpad to the center hub
+    public static final double HUMAN_PLAYER_SHOOTER_DISTANCE = 281.66;//distance from human shooter to center hub
+    public static final double FAR_SIDE_SHOOTER_DISTANCE = 300.0;//the side between launch pad and human shooter to center hub (least precise location)
 
     // chute subsystem
     public static final int CHUTE_CAN_ID = 6; 
@@ -186,6 +190,7 @@ public final class Constants {
 
     // robot starting distance
     public static final double STARTING_DISTANCE = TARMAC_DEFAULT_DISTANCE - 10.0;
+   
 
     // Xbox button mapping
     public static final int XBOX_A = 1;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -130,6 +130,20 @@ public class RobotContainer {
         // JoystickButton farm11 = new JoystickButton(m_farm, 11);
         // farm11.whenPressed(new ResetElevatorEncoder(m_climber));
 
+        //additional manual shooter position buttons(orange buttons)
+        JoystickButton farm4 = new JoystickButton(m_farm, 4);
+        farm6.whenPressed(new ShooterCommand(m_shooter, m_intake, Constants.FAR_SIDE_SHOOTER_DISTANCE, true));
+    
+        JoystickButton farm5 = new JoystickButton(m_farm, 5);
+        farm6.whenPressed(new ShooterCommand(m_shooter, m_intake, Constants.FAR_LAUNCHPAD_SHOOTER_DISTANCE, true));
+
+        JoystickButton farm9 = new JoystickButton(m_farm, 9);
+        farm6.whenPressed(new ShooterCommand(m_shooter, m_intake, Constants.CLOSE_LAUNCHPAD_SHOOTER_DISTANCE, true));
+
+        JoystickButton farm10 = new JoystickButton(m_farm, 10);
+        farm6.whenPressed(new ShooterCommand(m_shooter, m_intake, Constants.HUMAN_PLAYER_SHOOTER_DISTANCE, true));
+
+
         JoystickButton farm13 = new JoystickButton(m_farm, 13);
         farm13.whenPressed(new SetArmCoast(m_climber));
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -130,20 +130,21 @@ public class RobotContainer {
         // JoystickButton farm11 = new JoystickButton(m_farm, 11);
         // farm11.whenPressed(new ResetElevatorEncoder(m_climber));
 
-        //additional manual shooter position buttons(orange buttons)
+        // Additional manual shooter position buttons(orange buttons)
         JoystickButton farm4 = new JoystickButton(m_farm, 4);
-        farm6.whenPressed(new ShooterCommand(m_shooter, m_intake, Constants.FAR_SIDE_SHOOTER_DISTANCE, true));
+        farm4.whenPressed(new ShooterCommand(m_shooter, m_intake, Constants.TARMAC_DEFAULT_DISTANCE, true));
     
         JoystickButton farm5 = new JoystickButton(m_farm, 5);
-        farm6.whenPressed(new ShooterCommand(m_shooter, m_intake, Constants.FAR_LAUNCHPAD_SHOOTER_DISTANCE, true));
+        farm5.whenPressed(new ShooterCommand(m_shooter, m_intake, Constants.JUST_OUTSIDE_TARMAC, true));
 
         JoystickButton farm9 = new JoystickButton(m_farm, 9);
-        farm6.whenPressed(new ShooterCommand(m_shooter, m_intake, Constants.CLOSE_LAUNCHPAD_SHOOTER_DISTANCE, true));
+        farm9.whenPressed(new ShooterCommand(m_shooter, m_intake, Constants.CLOSE_LAUNCHPAD_SHOOTER_DISTANCE, true));
 
         JoystickButton farm10 = new JoystickButton(m_farm, 10);
-        farm6.whenPressed(new ShooterCommand(m_shooter, m_intake, Constants.HUMAN_PLAYER_SHOOTER_DISTANCE, true));
+        farm10.whenPressed(new ShooterCommand(m_shooter, m_intake, Constants.FAR_LAUNCHPAD_SHOOTER_DISTANCE, true));
+        // end additional shooter buttons
 
-
+        // Arm Brake/Coast buttons
         JoystickButton farm13 = new JoystickButton(m_farm, 13);
         farm13.whenPressed(new SetArmCoast(m_climber));
 

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -39,7 +39,11 @@ public class Shooter extends SubsystemBase {
             Map.entry(84.0, new ShooterSpeeds(1600.0, 1600.0, 0.3)),
             Map.entry(92.0, new ShooterSpeeds(1600.0, 1600.0, 0.3)),
             Map.entry(102.0, new ShooterSpeeds(1700.0, 1700.0, 0.3)),
-            Map.entry(163.0, new ShooterSpeeds(1800.0, 2100.0, 0.3))));
+            Map.entry(163.0, new ShooterSpeeds(1800.0, 2100.0, 0.3)),
+            // extrapolated entries for longer distances than we've tested
+            // see https://docs.google.com/spreadsheets/d/1n4-k0tSs-gYxqUTZAAVHsCi5a5Opg_p4OpYEWjNNB-U/edit?usp=sharing
+            Map.entry(180.0, new ShooterSpeeds(1885.0, 2156.8, 0.3)),
+            Map.entry(220.0, new ShooterSpeeds(2017.0, 2360.4, 0.3)) ));
 
     // values for lowerHub
     static final ShooterSpeeds lowHubSpeeds = new ShooterSpeeds(900.0, 900.0, 0.3);


### PR DESCRIPTION
Add four new shoot buttons using the Orange 4,5,9,10 set on the Farm controller.

4 - same as current shot
5 - about 2.5' further out
9 - near Launchpad shot
10 - far Launchpad shot